### PR TITLE
Updated token URL

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -22,10 +22,12 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
       - name: Acquire AWS credentials
-        uses: "yardbirdsax/action-aws-assume-federated-role@0.0.1"
+        uses: zarnovican/aws-oidc-login-action@v1.0.2
         with:
-          aws_iam_role_arn: "arn:aws:iam::068845349622:role/GHA-yardbirdsax-terraform-aws-github-action-federation-role"
-          aws_default_region: us-east-1
+          role: "arn:aws:iam::068845349622:role/GHA-yardbirdsax-terraform-aws-github-action-federation-role"
+          aws-region: us-east-1
+          client-id: sigstore
+          
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v1
         with:

--- a/.github/workflows/trunk.yaml
+++ b/.github/workflows/trunk.yaml
@@ -7,6 +7,9 @@ on:
        - ".github/**"
        - "README.md"
        - "LICENSE"
+permissions:
+  id-token: write
+  contents: read
 jobs:
   release:
     name: Generate release
@@ -15,10 +18,11 @@ jobs:
       - name: Check out
         uses: actions/checkout@v2
       - name: Acquire AWS credentials
-        uses: "yardbirdsax/action-aws-assume-federated-role@0.0.1"
+        uses: zarnovican/aws-oidc-login-action@v1.0.2
         with:
-          aws_iam_role_arn: "arn:aws:iam::068845349622:role/GHA-yardbirdsax-terraform-aws-github-action-federation-role"
-          aws_default_region: us-east-1
+          role: "arn:aws:iam::068845349622:role/GHA-yardbirdsax-terraform-aws-github-action-federation-role"
+          aws-region: us-east-1
+          client-id: sigstore
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v1
         with:

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
     }
     condition {
       test = "StringLike"
-      variable = "vstoken.actions.githubusercontent.com:sub"
+      variable = "token.actions.githubusercontent.com:sub"
       values = local.repository_ref_list
     }
   }


### PR DESCRIPTION
The GitHub token URL has been updated to match the new value that seems to be sent from GitHub.